### PR TITLE
Fixed nether & end tracking and compass recovery

### DIFF
--- a/data/manhunt/functions/load-core.mcfunction
+++ b/data/manhunt/functions/load-core.mcfunction
@@ -5,6 +5,7 @@ team modify Runner seeFriendlyInvisibles true
 team add Hunter
 team modify Hunter color blue
 team modify Hunter seeFriendlyInvisibles true
+scoreboard objectives add Dimension dummy
 scoreboard objectives add Deaths deathCount
 scoreboard objectives add RemainingLives dummy
 scoreboard objectives add Time dummy
@@ -20,13 +21,20 @@ scoreboard players enable @a Countdown
 scoreboard players enable @a Lives
 bossbar add countdown {"text":"Countdown"}
 bossbar set countdown visible false
-bossbar set countdown max 300
-forceload add 0 0
-setblock 0 -64 0 yellow_shulker_box 
+
+execute in minecraft:overworld run forceload add 0 0
+execute in minecraft:the_nether run forceload add 0 0
+execute in minecraft:the_end run forceload add 0 0
+
+execute in minecraft:overworld run setblock 0 0 0 yellow_shulker_box
+execute in minecraft:the_nether run setblock 0 0 0 yellow_shulker_box
+execute in minecraft:the_end run setblock 0 0 0 yellow_shulker_box
 
 # Loop
 schedule function manhunt:loop/locate 1
 schedule function manhunt:loop-core 1
+schedule function manhunt:load/recover-compass 1
+schedule function manhunt:loop/detect_dimension 1
 
 # Hello World
 function manhunt:load/hw

--- a/data/manhunt/functions/load/recover-compass.mcfunction
+++ b/data/manhunt/functions/load/recover-compass.mcfunction
@@ -1,0 +1,4 @@
+execute as @a[team=Hunter,scores={Deaths=1..}, nbt={DeathTime:0s}] run give @s compass{display:{Name:'{"text":"Tracker Compass","color": "aqua","italic": false}'}}
+execute as @a[team=Hunter,scores={Deaths=1..}, nbt={DeathTime:0s}] run scoreboard players set @s Deaths 0
+
+schedule function manhunt:load/recover-compass 100

--- a/data/manhunt/functions/loop-core.mcfunction
+++ b/data/manhunt/functions/loop-core.mcfunction
@@ -1,11 +1,8 @@
 # If holding compass, replace with updated compass
-execute as @a[team=Hunter] at @s if entity @s[nbt={SelectedItem:{id: "minecraft:compass", Count: 1b, tag: {display: {Name: '{"text":"Tracker Compass","color": "aqua","italic": false}'}}}}] if entity @a[team=Runner,distance=0..] run data modify storage manhunt:test Item.slot set value 0b
-execute as @a[team=Hunter] at @s if entity @s[nbt={SelectedItem:{id: "minecraft:compass", Count: 1b, tag: {display: {Name: '{"text":"Tracker Compass","color": "aqua","italic": false}'}}}}] if entity @a[team=Runner,distance=0..] run data modify block 0 -64 0 Items append from storage manhunt:test Item
-execute as @a[team=Hunter] at @s if entity @s[nbt={SelectedItem:{id: "minecraft:compass", Count: 1b, tag: {display: {Name: '{"text":"Tracker Compass","color": "aqua","italic": false}'}}}}] if entity @a[team=Runner,distance=0..] run loot replace entity @s weapon.mainhand 1 mine 0 -64 0 air{drop_contents: 1b}
+execute as @a[team=Hunter] at @s in minecraft:overworld if entity @s[nbt={SelectedItem:{id: "minecraft:compass", Count: 1b, tag: {display: {Name: '{"text":"Tracker Compass","color": "aqua","italic": false}'}}}}] if entity @a[team=Runner,distance=0..] run loot replace entity @s weapon.mainhand 1 mine 0 0 0 air{drop_contents: 1b}
+execute as @a[team=Hunter] at @s in minecraft:the_nether if entity @s[nbt={SelectedItem:{id: "minecraft:compass", Count: 1b, tag: {display: {Name: '{"text":"Tracker Compass","color": "aqua","italic": false}'}}}}] if entity @a[team=Runner,distance=0..] run loot replace entity @s weapon.mainhand 1 mine 0 0 0 air{drop_contents: 1b}
+execute as @a[team=Hunter] at @s in minecraft:the_end if entity @s[nbt={SelectedItem:{id: "minecraft:compass", Count: 1b, tag: {display: {Name: '{"text":"Tracker Compass","color": "aqua","italic": false}'}}}}] if entity @a[team=Runner,distance=0..] run loot replace entity @s weapon.mainhand 1 mine 0 0 0 air{drop_contents: 1b}
 
-# Give another compass upon death
-execute as @a[team=Hunter,scores={Deaths=1..}] run give @s compass{display:{Name:'{"text":"Tracker Compass","color": "aqua","italic": false}'}}
-execute as @a[team=Hunter,scores={Deaths=1..}] run scoreboard players set @s Deaths 0
 
 # Lives
 execute as @a[team=Runner,scores={Deaths=1..}] run scoreboard players remove @s RemainingLives 1
@@ -34,4 +31,5 @@ execute as @a[scores={manhunt-options=1..}] run scoreboard players enable @s man
 execute as @a[scores={manhunt-options=1..}] run scoreboard players set @s manhunt-options 0
 
 # Loop
-schedule function manhunt:loop-core 10
+
+schedule function manhunt:loop-core 10 

--- a/data/manhunt/functions/loop/detect_dimension.mcfunction
+++ b/data/manhunt/functions/loop/detect_dimension.mcfunction
@@ -1,0 +1,7 @@
+# Check if Hunter is in the same dimension as a runner and update compass
+execute as @a[team=Hunter,nbt={SelectedItem:{id:"minecraft:compass"}}] at @s if score @s Dimension = @a[team=Runner,limit=1,sort=nearest] Dimension run function manhunt:loop/locate
+
+# Update the dimension scoreboard to reflect the current dimension
+execute as @a store result score @s Dimension run data get entity @s Dimension
+
+schedule function manhunt:loop/detect_dimension 10t

--- a/data/manhunt/functions/loop/locate.mcfunction
+++ b/data/manhunt/functions/loop/locate.mcfunction
@@ -1,18 +1,18 @@
+# Loop
+schedule function manhunt:loop/locate 10t
+
 # Set dimension
 execute as @a[nbt={SelectedItem:{id: "minecraft:compass", Count: 1b, tag: {display: {Name: '{"text":"Tracker Compass","color": "aqua","italic": false}'}}}}] if data entity @s {Dimension:"minecraft:overworld"} if entity @a[team=Runner,gamemode=!spectator,distance=0..] run data modify storage manhunt:test Item set value {id: "minecraft:compass", tag: {display: {Name: '{"text":"Tracker Compass","color": "aqua","italic": false}'}, LodestoneTracked: 0b, LodestoneDimension:"minecraft:overworld", LodestonePos: {X:0,Y:0,Z:0}}, Count: 1b}
 execute as @a[nbt={SelectedItem:{id: "minecraft:compass", Count: 1b, tag: {display: {Name: '{"text":"Tracker Compass","color": "aqua","italic": false}'}}}}] if data entity @s {Dimension:"minecraft:the_end"} if entity @a[team=Runner,gamemode=!spectator,distance=0..] run data modify storage manhunt:test Item set value {id: "minecraft:compass", tag: {display: {Name: '{"text":"Tracker Compass","color": "aqua","italic": false}'}, LodestoneTracked: 0b, LodestoneDimension:"minecraft:the_end", LodestonePos: {X:0,Y:0,Z:0}}, Count: 1b}
 execute as @a[nbt={SelectedItem:{id: "minecraft:compass", Count: 1b, tag: {display: {Name: '{"text":"Tracker Compass","color": "aqua","italic": false}'}}}}] if data entity @s {Dimension:"minecraft:the_nether"} if entity @a[team=Runner,gamemode=!spectator,distance=0..] run data modify storage manhunt:test Item set value {id: "minecraft:compass", tag: {display: {Name: '{"text":"Tracker Compass","color": "aqua","italic": false}'}, LodestoneTracked: 0b, LodestoneDimension:"minecraft:the_nether", LodestonePos: {X:0,Y:0,Z:0}}, Count: 1b}
 
-# Get loc
+# Set position
 execute as @a[nbt={SelectedItem:{id: "minecraft:compass", Count: 1b, tag: {display: {Name: '{"text":"Tracker Compass","color": "aqua","italic": false}'}}}}] at @s if entity @a[team=Runner,gamemode=!spectator,distance=0..] store result storage manhunt:test Item.tag.LodestonePos.X int 1 run data get entity @a[team=Runner,gamemode=!spectator,limit=1,sort=nearest] Pos[0]
 execute as @a[nbt={SelectedItem:{id: "minecraft:compass", Count: 1b, tag: {display: {Name: '{"text":"Tracker Compass","color": "aqua","italic": false}'}}}}] at @s if entity @a[team=Runner,gamemode=!spectator,distance=0..] store result storage manhunt:test Item.tag.LodestonePos.Y int 1 run data get entity @a[team=Runner,gamemode=!spectator,limit=1,sort=nearest] Pos[1]
 execute as @a[nbt={SelectedItem:{id: "minecraft:compass", Count: 1b, tag: {display: {Name: '{"text":"Tracker Compass","color": "aqua","italic": false}'}}}}] at @s if entity @a[team=Runner,gamemode=!spectator,distance=0..] store result storage manhunt:test Item.tag.LodestonePos.Z int 1 run data get entity @a[team=Runner,gamemode=!spectator,limit=1,sort=nearest] Pos[2]
 
-execute as @a[nbt={SelectedItem:{id: "minecraft:compass", Count: 1b, tag: {display: {Name: '{"text":"Tracker Compass","color": "aqua","italic": false}'}}}}] at @s unless entity @a[team=Runner,gamemode=!spectator,distance=0..] run title @s actionbar {"text":"No player in dimension","color":"red"}
-execute as @a[nbt={SelectedItem:{id: "minecraft:compass", Count: 1b, tag: {display: {Name: '{"text":"Tracker Compass","color": "aqua","italic": false}'}}}}] at @s if entity @a[team=Runner,gamemode=!spectator,distance=0..] run title @s actionbar {"text":"Compass Refreshed","color":"green"}
 
+execute as @a[nbt={SelectedItem:{id: "minecraft:compass", Count: 1b, tag: {display: {Name: '{"text":"Tracker Compass","color": "aqua","italic": false}'}}}}] in minecraft:overworld run data modify block 0 0 0 Items append from storage manhunt:test Item
+execute as @a[nbt={SelectedItem:{id: "minecraft:compass", Count: 1b, tag: {display: {Name: '{"text":"Tracker Compass","color": "aqua","italic": false}'}}}}] in minecraft:the_nether run data modify block 0 0 0 Items append from storage manhunt:test Item
+execute as @a[nbt={SelectedItem:{id: "minecraft:compass", Count: 1b, tag: {display: {Name: '{"text":"Tracker Compass","color": "aqua","italic": false}'}}}}] in minecraft:the_end run data modify block 0 0 0 Items append from storage manhunt:test Item
 
-data modify block 0 -64 0 Items append from storage manhunt:test Item
-
-# Loop
-schedule function manhunt:loop/locate 10


### PR DESCRIPTION
Fixed some issues found. Nether and End tracking never worked for me, neither recovery of compass on death was handled correctly.

- Created 3 shulkers, one per dimension to update compasses, 
- Tracking dimensions of players and checking if the hunter(s) are in the runner(s) dimension *_here i did not track for multiple runners, so be aware._
- Recovery of compass is separated and handled in a different manner using "DeathTime" nbt.